### PR TITLE
Upgrades from Mapbox.js to Mapbox GL JS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
   globals: {
     Atomics: 'readonly',
     SharedArrayBuffer: 'readonly',
-    L: 'readonly'
+    mapboxgl: 'readonly'
   },
   parserOptions: {
     ecmaVersion: 2018,

--- a/index.html
+++ b/index.html
@@ -1,43 +1,40 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-    <head>
-        <title>Military Brat Map</title>
-        <meta charset='utf-8' />
-        <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-        <script src='https://api.mapbox.com/mapbox.js/v3.2.1/mapbox.js'></script>
-        <link href='https://api.mapbox.com/mapbox.js/v3.2.1/mapbox.css' rel='stylesheet' />
-        <link href='https://www.mapbox.com/base/latest/base.css' rel='stylesheet' />
-        <link href='styles.css' rel='stylesheet' type='text/css' />
-    </head>
-    <body class='unlimiter'>
+<head>
+<meta charset="utf-8" />
+<title>Military Brat Map</title>
+<meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
+<script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.6.1/mapbox-gl.js"></script>
+<link href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.6.1/mapbox-gl.css" rel="stylesheet" />
+<link href="https://www.mapbox.com/base/latest/base.css" rel="stylesheet" />
+<link href="styles.css" rel="stylesheet" type="text/css" />
+</head>
+<body class="unlimiter">
 
-    <div id='map-init' class='map'></div>
+<div id="map" class="map"></div>
 
-    <div class='pin-left pad1 col3'>
-        <div class='fill-white prose prose-small pad2 info round'>
-       
-        <h3>Where are you from?</h3>
-        <p>Easier to answer with a map.</p>
+<div class='pin-left pad1 col3'>
+  <div class='fill-white prose prose-small pad2 info round'>
+    <h3>Where are you from?</h3>
+    <p>Easier to answer with a map.</p>
+    <ol>
+      <li><a href="#" id='place-0'>Fort Bragg, NC</a></li>
+      <li><a href="#" id='place-1'>Los Angeles, CA</a></li>
+      <li><a href="#" id='place-2'>Fort Greeley, AK</a></li>
+      <li><a href="#" id='place-3'>Fort Leavenworth, KS</a></li>
+      <li><a href="#" id='place-4'>Springfield, VA</a></li>
+      <li><a href="#" id='place-5'>Monterey, CA</a></li>
+      <li><a href="#" id='place-6'>Paris, France</a></li>
+      <li><a href="#" id='place-7'>Hanscom Air Force Base, MA</a></li>
+      <li><a href="#" id='place-8'>Brussels, Belgium</a></li>
+      <li><a href="#" id='place-9'>Williamsburg, VA</a></li>
+      <li><a href="#" id='place-10'>Chengdu, China</a></li>
+      <li><a href="#" id='place-11'>Washington, DC</a></li>
+    </ol>
+  </div>
+</div>
 
-        <ol>
-            <li><a href="#" id='place-0'>Fort Bragg, NC</a></li>
-            <li><a href="#" id='place-1'>Los Angeles, CA</a></li>
-            <li><a href="#" id='place-2'>Fort Greeley, AK</a></li>
-            <li><a href="#" id='place-3'>Fort Leavenworth, KS</a></li>
-            <li><a href="#" id='place-4'>Springfield, VA</a></li>
-            <li><a href="#" id='place-5'>Monterey, CA</a></li>
-            <li><a href="#" id='place-6'>Paris, France</a></li>
-            <li><a href="#" id='place-7'>Hanscom Air Force Base, MA</a></li>
-            <li><a href="#" id='place-8'>Brussels, Belgium</a></li>
-            <li><a href="#" id='place-9'>Williamsburg, VA</a></li>
-            <li><a href="#" id='place-10'>Chengdu, China</a></li>
-            <li><a href="#" id='place-11'>Washington, DC</a></li>
-        </ol>
+<script src="map.js"></script>
 
-      </div>
-    </div>
-
-    <script src='map.js'></script>
-
-    </body>
+</body>
 </html>

--- a/map.js
+++ b/map.js
@@ -41,6 +41,126 @@ const markers = {
             description: '1990 - 1992',
           },
         },
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [-146.249099, 63.908265],
+          },
+          properties: {
+            title: 'Fort Greely, AK',
+            icon: 'park',
+            description: '1992 - 1995<br>Lots of moose.',
+          },
+        },
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [-94.9216, 39.3451],
+          },
+          properties: {
+            title: 'Fort Leavenworth, KS',
+            icon: 'bicycle',
+            description: '1995 - 1996<br>I learned to ride a bike here.',
+          },
+        },
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [-77.187, 38.7891],
+          },
+          properties: {
+            title: 'Springfield, VA',
+            icon: 'school',
+            description: '1996 - October 1998',
+          },
+        },
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [-121.8946, 36.6003],
+          },
+          properties: {
+            title: 'Monterey, CA',
+            icon: 'school',
+            description: 'October 1998 - July 1999<br>Defense Language Institute',
+          },
+        },
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [2.320582, 48.859489],
+          },
+          properties: {
+            title: 'Paris, France',
+            icon: 'school',
+            description: 'July 1999 - August 2004<br>Je me souviens.',
+          },
+        },
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [-71.277862, 42.46153],
+          },
+          properties: {
+            title: 'Hanscom Air Force Base, MA',
+            icon: 'school',
+            description: 'August 2004 - May 2008<br>High school.',
+          },
+        },
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [4.3488, 50.8504],
+          },
+          properties: {
+            title: 'Brussels, Belgium',
+            icon: 'town-hall',
+            description: 'May 2008 - July 2011<br>Winter and summer breaks from college.',
+          },
+        },
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [-76.7075, 37.2707],
+          },
+          properties: {
+            title: 'Williamsburg, Virginia',
+            icon: 'college',
+            description: 'August 2008 - May 2012<br>The College of William & Mary',
+          },
+        },
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [104.0667, 30.6636],
+          },
+          properties: {
+            title: 'Chengdu, China',
+            icon: 'college',
+            description: 'July-August 2011<br>Study Abroad',
+          },
+        },
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [-77.0366, 38.895],
+          },
+          properties: {
+            title: 'Washington, D.C.',
+            icon: 'rocket',
+            description: 'May 2012 - Present',
+          },
+        },
       ],
     },
   },

--- a/map.js
+++ b/map.js
@@ -1,204 +1,101 @@
-L.mapbox.accessToken = 'pk.eyJ1IjoiYWx1bHNoIiwiYSI6ImY0NDBjYTQ1NjU4OGJmMDFiMWQ1Y2RmYjRlMGI1ZjIzIn0.pngboKEPsfuC4j54XDT3VA';
+mapboxgl.accessToken = 'pk.eyJ1IjoiYWx1bHNoIiwiYSI6ImY0NDBjYTQ1NjU4OGJmMDFiMWQ1Y2RmYjRlMGI1ZjIzIn0.pngboKEPsfuC4j54XDT3VA';
 
-const map = L.mapbox.map('map-init', 'mapbox.streets', { zoomControl: false })
-  .setView([38.898, -77.043], 2);
+const map = new mapboxgl.Map({
+  container: 'map',
+  style: 'mapbox://styles/mapbox/streets-v11',
+  center: [-77.043, 38.898],
+  zoom: 2,
+});
 
-new L.Control.Zoom({ position: 'topright' }).addTo(map);
+map.addControl(new mapboxgl.NavigationControl());
 
 const markers = {
-  type: 'FeatureCollection',
-  features: [
-    {
-      type: 'Feature',
-      properties: {
-        title: 'Fort Bragg, NC',
-        'marker-symbol': 'heliport',
-        description: '1989 - 1990<br>I was born here. Have been back to visit once since.',
-      },
-      geometry: {
-        type: 'Point',
-        coordinates: [
-          -79.006,
-          35.139,
-        ],
-      },
+  id: 'places',
+  type: 'symbol',
+  source: {
+    type: 'geojson',
+    data: {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [-79.006, 35.139],
+          },
+          properties: {
+            title: 'Fort Bragg, NC',
+            icon: 'heliport',
+            description: '1989 - 1990<br>I was born here. Have been back to visit once since.',
+          },
+        },
+        {
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [-118.2427, 34.0537],
+          },
+          properties: {
+            title: 'Los Angeles, CA',
+            icon: 'heliport',
+            description: '1990 - 1992',
+          },
+        },
+      ],
     },
-    {
-      type: 'Feature',
-      properties: {
-        title: 'Los Angeles, CA',
-        'marker-symbol': 'heliport',
-        description: '1990 - 1992',
-      },
-      geometry: {
-        type: 'Point',
-        coordinates: [
-          -118.2427,
-          34.0537,
-        ],
-      },
-    },
-    {
-      type: 'Feature',
-      properties: {
-        title: 'Fort Greely, AK',
-        'marker-symbol': 'park',
-        description: '1992 - 1995<br>Lots of moose.',
-      },
-      geometry: {
-        type: 'Point',
-        coordinates: [
-          -146.249099,
-          63.908265,
-        ],
-      },
-    },
-    {
-      type: 'Feature',
-      properties: {
-        title: 'Fort Leavenworth, KS',
-        'marker-symbol': 'bicycle',
-        description: '1995 - 1996<br>I learned to ride a bike here.',
-      },
-      geometry: {
-        type: 'Point',
-        coordinates: [
-          -94.9216,
-          39.3451,
-        ],
-      },
-    },
-    {
-      type: 'Feature',
-      properties: {
-        title: 'Springfield, VA',
-        'marker-symbol': 'school',
-        description: '1996 - October 1998',
-      },
-      geometry: {
-        type: 'Point',
-        coordinates: [
-          -77.187,
-          38.7891,
-        ],
-      },
-    },
-    {
-      type: 'Feature',
-      properties: {
-        title: 'Monterey, CA',
-        'marker-symbol': 'school',
-        description: 'October 1998 - July 1999<br>Defense Language Institute',
-      },
-      geometry: {
-        type: 'Point',
-        coordinates: [
-          -121.8946,
-          36.6003,
-        ],
-      },
-    },
-    {
-      type: 'Feature',
-      properties: {
-        title: 'Paris, France',
-        'marker-symbol': 'school',
-        description: 'July 1999 - August 2004<br>Je me souviens.',
-      },
-      geometry: {
-        type: 'Point',
-        coordinates: [
-          2.320582,
-          48.859489,
-        ],
-      },
-    },
-    {
-      type: 'Feature',
-      properties: {
-        title: 'Hanscom Air Force Base, MA',
-        'marker-symbol': 'school',
-        description: 'August 2004 - May 2008<br>High school.',
-      },
-      geometry: {
-        type: 'Point',
-        coordinates: [
-          -71.277862,
-          42.46153,
-        ],
-      },
-    },
-    {
-      type: 'Feature',
-      properties: {
-        title: 'Brussels, Belgium',
-        'marker-symbol': 'town-hall',
-        description: 'May 2008 - July 2011<br>Winter and summer breaks from college.',
-      },
-      geometry: {
-        type: 'Point',
-        coordinates: [
-          4.3488,
-          50.8504,
-        ],
-      },
-    },
-    {
-      type: 'Feature',
-      properties: {
-        title: 'Williamsburg, Virginia',
-        'marker-symbol': 'college',
-        description: 'August 2008 - May 2012<br>The College of William & Mary',
-      },
-      geometry: {
-        type: 'Point',
-        coordinates: [
-          -76.7075,
-          37.2707,
-        ],
-      },
-    },
-    {
-      type: 'Feature',
-      properties: {
-        title: 'Chengdu, China',
-        'marker-symbol': 'college',
-        description: 'July-August 2011<br>Study Abroad',
-      },
-      geometry: {
-        type: 'Point',
-        coordinates: [
-          104.0667,
-          30.6636,
-        ],
-      },
-    },
-    {
-      type: 'Feature',
-      properties: {
-        title: 'Washington, D.C.',
-        'marker-symbol': 'rocket',
-        description: 'May 2012 - Present',
-      },
-      geometry: {
-        type: 'Point',
-        coordinates: [
-          -77.0366,
-          38.895,
-        ],
-      },
-    },
-  ],
+  },
+  layout: {
+    'icon-image': '{icon}-15',
+    'icon-allow-overlap': true,
+  },
 };
 
-const placesLayer = L.mapbox.featureLayer().setGeoJSON(markers).addTo(map);
+function createPopUpHtml(title, description) {
+  const popUpHTML = `<div class="markerTitle">${title}</div>${description}`;
+
+  return popUpHTML;
+}
+
+map.on('load', () => {
+  map.addLayer(markers);
+
+  map.on('click', 'places', (e) => {
+    const coordinates = e.features[0].geometry.coordinates.slice();
+    const { description } = e.features[0].properties;
+    const { title } = e.features[0].properties;
+
+    while (Math.abs(e.lngLat.lng - coordinates[0]) > 180) {
+      coordinates[0] += e.lngLat.lng > coordinates[0] ? 360 : -360;
+    }
+
+    new mapboxgl.Popup()
+      .setLngLat(coordinates)
+      .setHTML(createPopUpHtml(title, description))
+      .addTo(map);
+  });
+
+  map.on('mouseenter', 'places', () => {
+    map.getCanvas().style.cursor = 'pointer';
+  });
+
+  map.on('mouseleave', 'places', () => {
+    map.getCanvas().style.cursor = '';
+  });
+});
 
 function fly(lat, long, title) {
-  map.setView([lat, long], 7);
+  map.flyTo({
+    center: [long, lat],
+    zoom: 9,
+    essential: true,
+  });
 
-  placesLayer.eachLayer((marker) => {
-    if (marker.feature.properties.title === title) {
-      marker.openPopup();
+  markers.source.data.features.forEach((marker) => {
+    if (marker.properties.title === title) {
+      new mapboxgl.Popup()
+        .setLngLat([long, lat])
+        .setHTML(createPopUpHtml(marker.properties.title, marker.properties.description))
+        .addTo(map);
     }
   });
 }
@@ -212,7 +109,7 @@ function createEventListeners(index, lat, long, title) {
 }
 
 function loadPlaces(data) {
-  const places = data.features;
+  const places = data.source.data.features;
 
   for (let i = 0; i < places.length; i++) {
     const place = places[i];

--- a/map.js
+++ b/map.js
@@ -176,6 +176,8 @@ function createPopUpHtml(title, description) {
   return popUpHTML;
 }
 
+const popup = new mapboxgl.Popup();
+
 map.on('load', () => {
   map.addLayer(markers);
 
@@ -188,7 +190,7 @@ map.on('load', () => {
       coordinates[0] += e.lngLat.lng > coordinates[0] ? 360 : -360;
     }
 
-    new mapboxgl.Popup()
+    popup
       .setLngLat(coordinates)
       .setHTML(createPopUpHtml(title, description))
       .addTo(map);
@@ -212,7 +214,7 @@ function fly(lat, long, title) {
 
   markers.source.data.features.forEach((marker) => {
     if (marker.properties.title === title) {
-      new mapboxgl.Popup()
+      popup
         .setLngLat([long, lat])
         .setHTML(createPopUpHtml(marker.properties.title, marker.properties.description))
         .addTo(map);

--- a/styles.css
+++ b/styles.css
@@ -8,3 +8,7 @@
 	bottom: 0; 
 	width: 100%; 
 }
+
+.markerTitle {
+	font-weight: bold;
+}

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,8 @@
+body {
+	margin: 0;
+	padding: 0;
+}
+
 .info {
 	box-shadow: 0 1px 2px rgba(0,0,0,0.20); 
 }


### PR DESCRIPTION
This PR upgrades this map from Mapbox.js v3.2.1 to Mapbox GL JS v1.6.1.

* `index.html` and `map.js` now use Mapbox GL JS.
* Style edits to `index.html` for readability.
* Removes `L` global for Mapbox.js and replaces with `mapboxgl` global for Mapbox GL JS in the eslint config file.
* Adds `markerTitle` class for popups.